### PR TITLE
fix: parse classnames both as string (with tagname), and as "class" attribute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,15 +31,18 @@ function parse (args) {
     if (selector.classes !== '') {
       if (attrs.class) {
         if (attrs.class instanceof Array) {
-          attrs.class.push.apply(attrs.class, selector.classes.split(/[ ]+/g))
+          attrs.class = selector.classes.split(/[ ]+/g).concat(attrs.class)
         } else if (typeof attrs.class === 'string') {
-          attrs.class += ' ' + selector.classes
+          attrs.class = selector.classes + ' ' + attrs.class
         } else if (typeof attrs.class === 'object') {
+          const newClassesObj = {}
           selector.classes.split(/[ ]+/g).forEach(className => {
-            if (!(className in attrs.class)) {
-              attrs.class[className] = true;
-            }
+            newClassesObj[className] = true
           })
+          Object.keys(attrs.class).forEach(existing => {
+            newClassesObj[existing] = attrs.class[existing]
+          })
+          attrs.class = newClassesObj
         }
       } else {
         attrs.class = selector.classes

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,17 @@ function parse (args) {
 
     if (selector.classes !== '') {
       if (attrs.class) {
-        attrs.class = `${attrs.class} ${selector.classes}`
+        if (attrs.class instanceof Array) {
+          attrs.class.push.apply(attrs.class, selector.classes.split(/[ ]+/g))
+        } else if (typeof attrs.class === 'string') {
+          attrs.class += ' ' + selector.classes
+        } else if (typeof attrs.class === 'object') {
+          selector.classes.split(/[ ]+/g).forEach(className => {
+            if (!(className in attrs.class)) {
+              attrs.class[className] = true;
+            }
+          })
+        }
       } else {
         attrs.class = selector.classes
       }

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ test('parse selector', (t) => {
 
 test('parse selector class with attributes', (t) => {
   const obj = parse(['p.italic', { class: 'bold' }])
-  t.equal(obj.attrs.class, 'bold italic')
+  t.equal(obj.attrs.class, 'italic bold')
   t.end()
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -14,9 +14,21 @@ test('parse selector', (t) => {
   t.end()
 })
 
-test('parse selector class with attributes', (t) => {
+test('parse selector class with attributes class as string', (t) => {
   const obj = parse(['p.italic', { class: 'bold' }])
   t.equal(obj.attrs.class, 'italic bold')
+  t.end()
+})
+
+test('parse selector class with attributes class as array', (t) => {
+  const obj = parse(['p.italic', { class: ['bold'] }])
+  t.deepEqual(obj.attrs.class, ['italic', 'bold'])
+  t.end()
+})
+
+test('parse selector class with attributes class as object', (t) => {
+  const obj = parse(['p.italic', { class: {bold: true} }])
+  t.deepEqual(obj.attrs.class, {italic: true, bold: true})
   t.end()
 })
 


### PR DESCRIPTION
Fixes when you have a usecase like this (which didn't work)

```
h('div.one', {class: {two: true}}, [...])`
```

It made the class `[object Object] one`

This fixes it.

Fixes https://github.com/queckezz/preact-hyperscript/issues/3